### PR TITLE
Update swallow.py

### DIFF
--- a/src/smolqwery/swallow.py
+++ b/src/smolqwery/swallow.py
@@ -79,8 +79,9 @@ class Migration(migrations.Migration):
     dependencies = {dependencies!r}
 
     coconut = Coconut({[*self.schemas]!r})
-
-    operations = [migrations.RunPython(coconut.forward, coconut.backward)]
+    # Remove migration when running tests to avoid duplicating tables in BQ
+    if not 'test' in sys.argv:
+        operations = [migrations.RunPython(coconut.forward, coconut.backward)]
 """
 
     def generate_django_migration_name(self) -> str:


### PR DESCRIPTION
feat: ignore smolqwery migration when running django test